### PR TITLE
Add states field to Country type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6707,6 +6707,11 @@
         "long": "^4.0.0"
       }
     },
+    "provinces": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/provinces/-/provinces-1.11.0.tgz",
+      "integrity": "sha1-Rni9Y+iBHwoZTrwcV+7hxV585sI="
+    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "apollo-server": "^2.7.0",
     "countries-list": "^2.4.3",
     "esm": "^3.2.25",
-    "graphql": "^14.4.2"
+    "graphql": "^14.4.2",
+    "provinces": "^1.11.0"
   },
   "devDependencies": {
     "@trevorblades/eslint-config": "^7.0.1",

--- a/resolvers.js
+++ b/resolvers.js
@@ -1,3 +1,4 @@
+import provinces from 'provinces';
 import {continents, countries, languages} from 'countries-list';
 
 export default {
@@ -8,20 +9,31 @@ export default {
         name: continents[continent]
       };
     },
-    languages(parent) {
-      return parent.languages.map(code => {
+    languages(country) {
+      return country.languages.map(code => {
         const language = languages[code];
         return {
           ...language,
           code
         };
       });
+    },
+    states(country) {
+      return provinces.filter(province => province.country === country.code);
+    }
+  },
+  State: {
+    code(state) {
+      return state.short;
+    },
+    country(state) {
+      return countries[state.country];
     }
   },
   Continent: {
-    countries(parent) {
+    countries(continent) {
       return Object.entries(countries)
-        .filter(entry => entry[1].continent === parent.code)
+        .filter(entry => entry[1].continent === continent.code)
         .map(([code, country]) => ({
           ...country,
           code

--- a/schema.js
+++ b/schema.js
@@ -17,6 +17,13 @@ export default gql`
     languages: [Language]
     emoji: String
     emojiU: String
+    states: [State]
+  }
+
+  type State {
+    code: String
+    name: String
+    country: Country
   }
 
   type Language {


### PR DESCRIPTION
This PR adds a `states` field to each country, with data sourced from https://github.com/substack/provinces/blob/master/provinces.json.

The only difference between the data in that JSON file and the shape of a `State` in this API is that we call their `short` field `code` instead for consistency with the other types in this API.